### PR TITLE
fix(变更展示): 展示逐文件 Diff 并禁止写入 workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ flowchart TB
 | `Mcp-Session-Id`    | 临时，可在重连或切换客户端时变化      | Streamable HTTP 传输状态                                         |
 | `remote_session_id` | SQLite 持久化，可跨连接和进程重启查询 | Workspace、成员权限、Changeset、任务、审批、快照和产物的业务主键 |
 
-源码修改默认采用 Diff First 流程：读取源码与 SHA-256 → 准备 Changeset → 展示 Unified Diff → 校验 revision 和策略 → 事务应用。工具结果内联返回（上限 `limits.max_result_bytes`，默认 256KB）：命令 stdout/stderr 直接内联，Diff 返回预览；完整 Unified Diff 持久化在 `{workspace}/.mcpx/diffs/<changeset_id>.diff`，任务日志和已注册 Artifact 可通过 `mcpx://remote-sessions/...` Resource Link 读取。
+源码修改默认采用 Diff First 流程：读取源码与 SHA-256 → 准备 Changeset → 展示 Unified Diff → 校验 revision 和策略 → 事务应用。工具结果内联返回（上限 `limits.max_result_bytes`，默认 256KB）：命令 stdout/stderr 直接内联，变更文件条目包含每文件 Diff 预览；完整 Unified Diff 保存在 Changeset 状态中，并可通过 `mcpx://remote-sessions/...` Resource Link 读取，不会写入 workspace。
 
 ---
 
@@ -339,26 +339,26 @@ curl -sS -m 5 \
 
 客户端里名称形如 **`mcpx__workspace_list`**（服务器名 + 双下划线 + 工具名）。
 
-| 类别 | 工具 | 用途 |
-| --- | --- | --- |
-| 高频开发 | `workspace_list` | 查询已注册 Workspace。 |
-| 高频开发 | `session_open` | 一次创建或恢复 Remote Session，并返回初始化上下文。 |
-| 高频开发 | `file_read` | 读取单文件或 `items[]` 批量文件窗口，返回独立 SHA-256；修改前必须先读取当前内容。 |
-| 高频开发 | `context_query` | 通过 `query` / `search` / `list` 动作获取受预算限制的源码上下文。 |
-| 高频开发 | `change_execute` | 一次完成普通修改的 Changeset、策略检查、原子 Apply 和可选验证。 |
-| 高频开发 | `command_execute` | 执行命令或项目任务；10 秒内返回结果，超时转统一 Task；stdout/stderr 内联返回（上限 256KB）。 |
-| 领域管理 | `session_manage` | `list`、`get`、`events`、`update`、`handoff`、`attach`、`close`。 |
-| 领域管理 | `change_manage` | 仅用于 `prepare`、`diff`、`history`；Apply 和回滚统一通过 `change_execute`。 |
-| 领域管理 | `plan_manage` | 创建与推进持久化开发 Plan（`create` / `advance` / `list` / `get`…），只管理计划状态与证据。 |
-| 领域管理 | `task_manage` | `attach`、`status`、`logs`、`list`、`stop`、`ports`、`diagnostics`、`stdin`。 |
-| 领域管理 | `runtime_inspect` | `capabilities`、`project`、`instructions`。 |
-| 领域管理 | `environment_inspect` | 查看环境并保存或比较快照。 |
-| 领域管理 | `workspace_state` | `changes`、`snapshot`、`diff`、`watch`。 |
-| 领域管理 | `extension_manage` | 统一 `list`、`describe`、`call` Skills 和上游 MCP。 |
-| 领域管理 | `artifact_manage` | `list`、`read`、`register` Artifact。 |
-| 领域管理 | `approval_manage` | `list`、`approve`、`deny` 高风险操作。 |
-| 特殊能力 | `screenshot_capture` | 截取显示器或区域。 |
-| 特殊能力 | `secrets_provide` | 提供仅进程内可用的 Secret 引用。 |
+| 类别     | 工具                  | 用途                                                                                         |
+| -------- | --------------------- | -------------------------------------------------------------------------------------------- |
+| 高频开发 | `workspace_list`      | 查询已注册 Workspace。                                                                       |
+| 高频开发 | `session_open`        | 一次创建或恢复 Remote Session，并返回初始化上下文。                                          |
+| 高频开发 | `file_read`           | 读取单文件或 `items[]` 批量文件窗口，返回独立 SHA-256；修改前必须先读取当前内容。            |
+| 高频开发 | `context_query`       | 通过 `query` / `search` / `list` 动作获取受预算限制的源码上下文。                            |
+| 高频开发 | `change_execute`      | 一次完成普通修改的 Changeset、策略检查、原子 Apply 和可选验证。                              |
+| 高频开发 | `command_execute`     | 执行命令或项目任务；10 秒内返回结果，超时转统一 Task；stdout/stderr 内联返回（上限 256KB）。 |
+| 领域管理 | `session_manage`      | `list`、`get`、`events`、`update`、`handoff`、`attach`、`close`。                            |
+| 领域管理 | `change_manage`       | 仅用于 `prepare`、`diff`、`history`；Apply 和回滚统一通过 `change_execute`。                 |
+| 领域管理 | `plan_manage`         | 创建与推进持久化开发 Plan（`create` / `advance` / `list` / `get`…），只管理计划状态与证据。  |
+| 领域管理 | `task_manage`         | `attach`、`status`、`logs`、`list`、`stop`、`ports`、`diagnostics`、`stdin`。                |
+| 领域管理 | `runtime_inspect`     | `capabilities`、`project`、`instructions`。                                                  |
+| 领域管理 | `environment_inspect` | 查看环境并保存或比较快照。                                                                   |
+| 领域管理 | `workspace_state`     | `changes`、`snapshot`、`diff`、`watch`。                                                     |
+| 领域管理 | `extension_manage`    | 统一 `list`、`describe`、`call` Skills 和上游 MCP。                                          |
+| 领域管理 | `artifact_manage`     | `list`、`read`、`register` Artifact。                                                        |
+| 领域管理 | `approval_manage`     | `list`、`approve`、`deny` 高风险操作。                                                       |
+| 特殊能力 | `screenshot_capture`  | 截取显示器或区域。                                                                           |
+| 特殊能力 | `secrets_provide`     | 提供仅进程内可用的 Secret 引用。                                                             |
 
 `tools/list` 只暴露以上 **18** 个工具。低频操作必须通过其领域工具的 `action` 分支调用；文件读取和普通修改分别统一使用 `file_read`、`change_execute`。所有直接文件修改都必须经过 `change_execute`，不能通过 `command_execute` 或 `change_manage` 绕过。
 
@@ -371,7 +371,7 @@ curl -sS -m 5 \
 5. 用 `command_execute` 运行测试或命令；超过 10 秒时按响应中的 `task_manage(action="attach")` 继续。
 6. 用 `workspace_state(action="changes")` 检查最终变更；跨客户端接力使用 `session_manage(action="handoff" | "attach")`。
 
-大型 Unified Diff、任务日志和已注册 Artifact 通过 `mcpx://remote-sessions/...` Resource 读取。命令输出与 Diff 预览默认内联（上限 256KB），超过时返回截断提示与持久化文件位置，`content` 只保留模型摘要，大内容不会在多个响应字段中镜像。
+大型 Unified Diff、任务日志和已注册 Artifact 通过 `mcpx://remote-sessions/...` Resource 读取。命令输出与 Diff 预览默认内联（上限 256KB），代码变更 UI 和工具文本按文件展示具体增删内容，超过时返回截断提示与 Resource Link；完整大内容不会在多个响应字段中镜像。
 
 ### 机器可读能力发现
 
@@ -380,7 +380,7 @@ MCP 标准 `tools/list` 是工具名称、描述、参数 JSON Schema 和 Annota
 - `tool_schema_revision`：由实际注册工具的名称、描述、Schema 与 Annotation 计算；新建 Session 不会改变它。
 - `capability_manifest_revision`、`guidance_revision`、`instruction_revision`、`skill_revision`、`mcp_revision`、`session_capability_revision`：可分别判断哪些能力需要刷新。
 - `tools`：每个公开工具的领域、状态、角色限制和是否要求 `remote_session_id`。
-- `agent_guidance`、`instructions`、Skills、上游 MCP、Resource URI 模板和推荐调用链。`agent_guidance` 默认返回，不受指令正文或上游发现开关影响。
+- `agent_guidance`、`instructions`、Skills、上游 MCP、Resource URI 模板和推荐调用链。`agent_guidance` 默认返回，不受指令正文或上游发现开关影响；其中 `response_contract` 要求模型在重要操作前说明目的、完成后报告真实结果、文件变更、验证证据与风险，不得无证据宣称完成。
 
 客户端首次连接应调用 `tools/list`；绑定 Workspace 或 Remote Session 后调用 `runtime_inspect(action="capabilities")`。`session_open` 接受 `known_revisions`，未变化的 Skills、上游 MCP、指令和 Session capability 会在响应中标为 `omitted`，避免重复传输。
 
@@ -415,14 +415,14 @@ MCP 标准 `tools/list` 是工具名称、描述、参数 JSON Schema 和 Annota
 
 除 `patch` 外，`operations` 还支持按内容精确编辑的快捷操作，均要求 `base_sha256`（当前 revision）：
 
-| 操作 | 参数 | 用途 |
-| --- | --- | --- |
-| `replace_exact` | `match` + `content` | 精确替换唯一出现的一段文本 |
-| `insert_before` / `insert_after` | `match` + `content` | 在某段文本前/后插入（插入完整行时 `content` 需自带结尾换行） |
-| `delete_exact` | `match` | 删除唯一出现的一段文本 |
-| `replace_range` | `range_start` + `range_end` + `content` | 按 1 起始行号替换区间，适合大文件局部修改 |
+| 操作                             | 参数                                    | 用途                                                         |
+| -------------------------------- | --------------------------------------- | ------------------------------------------------------------ |
+| `replace_exact`                  | `match` + `content`                     | 精确替换唯一出现的一段文本                                   |
+| `insert_before` / `insert_after` | `match` + `content`                     | 在某段文本前/后插入（插入完整行时 `content` 需自带结尾换行） |
+| `delete_exact`                   | `match`                                 | 删除唯一出现的一段文本                                       |
+| `replace_range`                  | `range_start` + `range_end` + `content` | 按 1 起始行号替换区间，适合大文件局部修改                    |
 
-行尾兼容：提交的 `content` / `patch` / `match` 会自动归一化到目标文件的换行符（CRLF/LF），小改动不会翻转整个文件的行尾风格。`security.files.max_patch_lines` 按**真实差异行数**计算（公共前缀/后缀之外的中间段），大文件内的小改动不会被误判超限；全量替换则按整体行数计，超限会返回 `PATCH_TOO_LARGE` 及拆分建议。完整 Diff 预览内联返回，全文持久化在 `{workspace}/.mcpx/diffs/<changeset_id>.diff`。
+行尾兼容：提交的 `content` / `patch` / `match` 会自动归一化到目标文件的换行符（CRLF/LF），小改动不会翻转整个文件的行尾风格。`security.files.max_patch_lines` 按**真实差异行数**计算（公共前缀/后缀之外的中间段），大文件内的小改动不会被误判超限；全量替换则按整体行数计，超限会返回 `PATCH_TOO_LARGE` 及拆分建议。完整 Diff 预览内联返回，每个文件条目同时提供受限 Diff 预览，全文通过 Changeset Resource 读取，不会写入 workspace。
 
 截图工具使用 `environment_inspect` 返回的显示器索引。`fullscreen` 截取完整显示器；`region` 使用全局 `x / y / width / height` 坐标。`compression` 支持 `none`、`balanced` 和 `small`。截图只通过 MCP 响应返回，不默认写入项目或 SQLite。
 
@@ -548,11 +548,13 @@ MCPX 仅用于学习、研究和经授权的开发环境自动化。使用者应
 
 ## Star History
 
-<a href="https://www.star-history.com/?type=date&repos=opentokenz%2Fmcpx">
+## Star History
+
+<a href="https://www.star-history.com/?repos=opentokenz%2Fmcpx&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&theme=dark&legend=top-left&sealed_token=PoZfjzlwyeL85OQdDvxeP6Blj9F9VUyGyuIeGt7ZmSapcaehW_KhED6OQScGiTNktj67Qr3rHEUlx3HlP9dwISaLzajjiKSnz7IycM3hik-OwrPhQftqpfXSt13q5uysWBPGr4Z0BsBzfm0beORdMaKoevID9qcnKL3-q4LrKGInQJZaioUTS-KE5uJ-" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&legend=top-left&sealed_token=PoZfjzlwyeL85OQdDvxeP6Blj9F9VUyGyuIeGt7ZmSapcaehW_KhED6OQScGiTNktj67Qr3rHEUlx3HlP9dwISaLzajjiKSnz7IycM3hik-OwrPhQftqpfXSt13q5uysWBPGr4Z0BsBzfm0beORdMaKoevID9qcnKL3-q4LrKGInQJZaioUTS-KE5uJ-" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&legend=top-left&sealed_token=PoZfjzlwyeL85OQdDvxeP6Blj9F9VUyGyuIeGt7ZmSapcaehW_KhED6OQScGiTNktj67Qr3rHEUlx3HlP9dwISaLzajjiKSnz7IycM3hik-OwrPhQftqpfXSt13q5uysWBPGr4Z0BsBzfm0beORdMaKoevID9qcnKL3-q4LrKGInQJZaioUTS-KE5uJ-" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&theme=dark&legend=top-left&sealed_token=jUtxc1OYmFK08WQj99XkmFzM0HRA-hpQB7I9wHBLMBGHx-67q1wA2YAs4xsVkz5atYfU4hBNzBeZ1PgKY6SZM1t4MY6U70cFpKG49h7I-p1HEzbjWiJMh5EIJ2wl7Mc4ihBZ05TXuvpgxIR_0SppHmEn18A66kOXgnljlPGZm18kCP52p6jPzPM1hH_v" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&legend=top-left&sealed_token=jUtxc1OYmFK08WQj99XkmFzM0HRA-hpQB7I9wHBLMBGHx-67q1wA2YAs4xsVkz5atYfU4hBNzBeZ1PgKY6SZM1t4MY6U70cFpKG49h7I-p1HEzbjWiJMh5EIJ2wl7Mc4ihBZ05TXuvpgxIR_0SppHmEn18A66kOXgnljlPGZm18kCP52p6jPzPM1hH_v" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=opentokenz/mcpx&type=date&legend=top-left&sealed_token=jUtxc1OYmFK08WQj99XkmFzM0HRA-hpQB7I9wHBLMBGHx-67q1wA2YAs4xsVkz5atYfU4hBNzBeZ1PgKY6SZM1t4MY6U70cFpKG49h7I-p1HEzbjWiJMh5EIJ2wl7Mc4ihBZ05TXuvpgxIR_0SppHmEn18A66kOXgnljlPGZm18kCP52p6jPzPM1hH_v" />
  </picture>
 </a>
 

--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -191,7 +191,11 @@ func classify(tool string, isError bool, data map[string]any, summary string) (s
 		if status == "need_confirmation" || status == "need_secret" || hasAnyKey(data, "approval_id") {
 			behavior = "ask_confirm"
 		}
-		return "error", errorData(data), Hints{PreferredBehavior: behavior}, actionsFrom(data)
+		errorResult := errorData(data)
+		if hasAnyKey(errorResult, "changeset_id") && hasAnyKey(errorResult, "files", "diff") {
+			return "code_change", errorResult, Hints{PreferredBehavior: behavior}, actionsFrom(data)
+		}
+		return "error", errorResult, Hints{PreferredBehavior: behavior}, actionsFrom(data)
 	}
 
 	inner := nestedData(data)
@@ -523,7 +527,11 @@ func resultDataSchema(name string) map[string]any {
 		return object(map[string]any{
 			"changeset_id": map[string]any{"type": "string"}, "status": map[string]any{"type": "string"},
 			"summary": map[string]any{"type": "string"}, "digest": map[string]any{"type": "string"},
-			"files": map[string]any{"type": "array", "items": map[string]any{"type": "object"}}, "diff": map[string]any{"type": "object"},
+			"files": map[string]any{"type": "array", "items": map[string]any{"type": "object", "properties": map[string]any{
+				"path": map[string]any{"type": "string"}, "new_path": map[string]any{"type": "string"},
+				"operation": map[string]any{"type": "string"}, "diff": map[string]any{"type": "string"},
+				"diff_truncated": map[string]any{"type": "boolean"},
+			}}}, "diff": map[string]any{"type": "object"},
 			"applied": map[string]any{"type": "boolean"}, "verify": map[string]any{"type": "array", "items": map[string]any{"type": "object"}},
 		})
 	case SchemaTable:

--- a/internal/arc/arc_test.go
+++ b/internal/arc/arc_test.go
@@ -2,6 +2,7 @@ package arc
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -71,6 +72,24 @@ func TestWrapToolResultMapsApprovalToErrorAction(t *testing.T) {
 	actions := result["actions"].([]any)
 	if len(actions) != 1 || actions[0].(map[string]any)["type"] != "approval" {
 		t.Fatalf("actions = %+v", actions)
+	}
+}
+
+func TestWrapToolResultRendersApprovalCodeChangeDiff(t *testing.T) {
+	raw := mcp.NewToolResultText(`{"ok":false,"status":"need_confirmation","data":{"approval_id":"ap_123","changeset_id":"chg_approval","files":[{"path":"demo.go","operation":"update","diff":"--- a/demo.go\n+++ b/demo.go\n@@ -1 +1 @@\n-const Value = 1\n+const Value = 2\n"}],"diff":{"mode":"inline","resource_uri":"mcpx://remote-sessions/rs1/changesets/chg_approval/diff"},"next_action":{"tool":"approval_manage","arguments":{"action":"approve","approval_id":"ap_123"}}},"error":{"code":"APPROVAL_REQUIRED","message":"approval required"}}`)
+	written := WrapToolResult("change_execute", ResultContext{}, raw)
+	result := decodeEnvelope(t, written)["mcpx"].(map[string]any)["result"].(map[string]any)
+	if result["type"] != "code_change" || result["schema"] != SchemaCodeChange {
+		t.Fatalf("result = %+v", result)
+	}
+	if result["hints"].(map[string]any)["preferred_behavior"] != "ask_confirm" {
+		t.Fatalf("hints = %+v", result["hints"])
+	}
+	text := written.Content[0].(mcp.TextContent).Text
+	for _, want := range []string{"需要确认后才能应用", "```diff", "-const Value = 1", "+const Value = 2"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("approval diff missing %q: %s", want, text)
+		}
 	}
 }
 

--- a/internal/arc/presentation.go
+++ b/internal/arc/presentation.go
@@ -116,7 +116,7 @@ func hostSupports(host HostCapabilities, renderer string) bool {
 }
 
 // renderDiffMaxLines caps the inline diff shown in the host-visible text.
-// Larger diffs point to the persisted diff file (see change_execute results).
+// Larger diffs point to the Changeset Resource (see change_execute results).
 const renderDiffMaxLines = 200
 
 // RenderContent builds the host-visible text for a result according to the
@@ -141,6 +141,9 @@ func renderCodeChange(data map[string]any) string {
 	if changesetID != "" {
 		fmt.Fprintf(&b, "### Changeset %s", changesetID)
 	}
+	if status, _ := data["status"].(string); status == "need_confirmation" {
+		b.WriteString("\n\n> ⚠️ 此变更需要确认后才能应用。")
+	}
 	diffMeta, _ := data["diff"].(map[string]any)
 	diffText, _ := diffMeta["unified_diff"].(string)
 	if diffText == "" {
@@ -151,10 +154,10 @@ func renderCodeChange(data map[string]any) string {
 		fmt.Fprintf(&b, " · +%d −%d", totalAdded, totalRemoved)
 	}
 	fileStats := diffStatsByPath(diffText)
-	if files, ok := data["files"].([]any); ok && len(files) > 0 {
+	files := changeFiles(data["files"])
+	if len(files) > 0 {
 		b.WriteString("\n\n| 文件 | 操作 | 变更 |\n|---|---|---|\n")
-		for _, raw := range files {
-			file, _ := raw.(map[string]any)
+		for _, file := range files {
 			path, _ := file["path"].(string)
 			op, _ := file["operation"].(string)
 			if path == "" {
@@ -163,7 +166,8 @@ func renderCodeChange(data map[string]any) string {
 			fmt.Fprintf(&b, "| `%s` | %s | %s |\n", path, op, formatDiffStats(fileStats[path]))
 		}
 	}
-	if diffText != "" {
+	fileDiffRendered, fileDiffTruncated := renderFileDiffs(&b, files)
+	if !fileDiffRendered && diffText != "" {
 		display, truncated := trimDiffForRender(diffText)
 		b.WriteString("\n```diff\n")
 		b.WriteString(display)
@@ -171,14 +175,69 @@ func renderCodeChange(data map[string]any) string {
 		if truncated {
 			resourceURI, _ := diffMeta["resource_uri"].(string)
 			if resourceURI != "" {
-				b.WriteString("\n> 剩余部分见 Resource 或 diff 文件。\n")
+				b.WriteString("\n> 剩余部分见 Changeset Resource。\n")
+			}
+		}
+	} else if fileDiffRendered {
+		fileDiffTruncated = fileDiffTruncated || diffMeta["mode"] == "resource"
+		if fileDiffTruncated {
+			resourceURI, _ := diffMeta["resource_uri"].(string)
+			if resourceURI != "" {
+				b.WriteString("\n\n> 完整变更见 Changeset Resource。")
 			}
 		}
 	}
-	if diffFile, _ := data["diff_file"].(string); diffFile != "" {
-		fmt.Fprintf(&b, "\n完整 diff 已写入 `%s`（可用 `file_read` 读取）\n", diffFile)
-	}
 	return strings.TrimSpace(b.String())
+}
+
+func changeFiles(value any) []map[string]any {
+	switch files := value.(type) {
+	case []map[string]any:
+		return files
+	case []any:
+		result := make([]map[string]any, 0, len(files))
+		for _, raw := range files {
+			if file, ok := raw.(map[string]any); ok {
+				result = append(result, file)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func renderFileDiffs(builder *strings.Builder, files []map[string]any) (rendered, truncated bool) {
+	for _, file := range files {
+		diff, _ := file["diff"].(string)
+		if strings.TrimSpace(diff) == "" {
+			continue
+		}
+		path, _ := file["path"].(string)
+		if path == "" {
+			continue
+		}
+		label := path
+		if newPath, _ := file["new_path"].(string); newPath != "" && newPath != path {
+			label += " → " + newPath
+		}
+		op, _ := file["operation"].(string)
+		builder.WriteString("\n\n#### `")
+		builder.WriteString(label)
+		builder.WriteString("`")
+		if op != "" {
+			builder.WriteString(" · ")
+			builder.WriteString(op)
+		}
+		builder.WriteString("\n\n```diff\n")
+		builder.WriteString(diff)
+		builder.WriteString("\n```")
+		rendered = true
+		if value, _ := file["diff_truncated"].(bool); value {
+			truncated = true
+		}
+	}
+	return rendered, truncated
 }
 
 type diffStats struct {
@@ -191,15 +250,33 @@ type diffStats struct {
 func diffStatsByPath(diffText string) map[string]diffStats {
 	stats := make(map[string]diffStats)
 	path := ""
+	oldPath := ""
+	inHunk := false
 	for _, line := range strings.Split(diffText, "\n") {
 		if strings.HasPrefix(line, "diff --git ") {
 			path = diffPathFromHeader(line)
+			inHunk = false
 			if path != "" {
 				stats[path] = diffStats{}
 			}
 			continue
 		}
-		if path == "" || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+		if !inHunk && strings.HasPrefix(line, "--- ") {
+			oldPath = strings.TrimPrefix(line, "--- ")
+			continue
+		}
+		if !inHunk && strings.HasPrefix(line, "+++ ") {
+			path = diffPathFromUnifiedHeaders(oldPath, strings.TrimPrefix(line, "+++ "))
+			if path != "" {
+				stats[path] = diffStats{}
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "@@ ") {
+			inHunk = true
+			continue
+		}
+		if !inHunk || path == "" {
 			continue
 		}
 		switch {
@@ -214,6 +291,15 @@ func diffStatsByPath(diffText string) map[string]diffStats {
 		}
 	}
 	return stats
+}
+
+func diffPathFromUnifiedHeaders(oldPath, newPath string) string {
+	oldPath = strings.TrimPrefix(oldPath, "a/")
+	newPath = strings.TrimPrefix(newPath, "b/")
+	if newPath != "/dev/null" && newPath != "" {
+		return newPath
+	}
+	return oldPath
 }
 
 func diffPathFromHeader(line string) string {

--- a/internal/arc/presentation_test.go
+++ b/internal/arc/presentation_test.go
@@ -18,13 +18,12 @@ func TestRenderContentRendersCodeChangeDiff(t *testing.T) {
 			"resource_uri":  "mcpx://remote-sessions/rs1/changesets/chg_1/diff",
 			"preview_lines": 100,
 		},
-		"diff_file": ".mcpx/diffs/chg_1.diff",
 	}
 	text, ok := RenderContent("code_change", "diff", "summary text", data)
 	if !ok {
 		t.Fatal("code_change diff renderer must produce a dedicated view")
 	}
-	for _, want := range []string{"### Changeset chg_1", "| `demo.go` | update | +1 −1 |", "```diff", diff, "`.mcpx/diffs/chg_1.diff`"} {
+	for _, want := range []string{"### Changeset chg_1", "| `demo.go` | update | +1 −1 |", "```diff", diff} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("rendered diff missing %q:\n%s", want, text)
 		}
@@ -107,6 +106,32 @@ func TestRenderContentReportsPerFileDiffStats(t *testing.T) {
 	text, ok := RenderContent("code_change", "diff", "summary", data)
 	if !ok || !strings.Contains(text, "| `one.go` | update | +1 −0 |") || !strings.Contains(text, "| `two.go` | update | +1 −1 |") {
 		t.Fatalf("per-file diff stats = (%q, %v)", text, ok)
+	}
+}
+
+func TestRenderContentShowsPerFileDiffDetails(t *testing.T) {
+	path := "ChatGPT-互联网医院小程序修复.txt"
+	data := map[string]any{
+		"changeset_id": "chg_detail",
+		"files": []map[string]any{{
+			"path":      path,
+			"operation": "update",
+			"diff":      "--- a/" + path + "\n+++ b/" + path + "\n@@ -1 +1 @@\n-旧消息链路\n+新消息链路\n",
+		}},
+		"diff": map[string]any{
+			"mode":         "inline",
+			"resource_uri": "mcpx://remote-sessions/rs1/changesets/chg_detail/diff",
+		},
+	}
+
+	text, ok := RenderContent("code_change", "diff", "summary", data)
+	if !ok {
+		t.Fatal("code_change diff renderer must produce a dedicated view")
+	}
+	for _, want := range []string{"#### `" + path + "`", "-旧消息链路", "+新消息链路"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("per-file diff detail missing %q:\n%s", want, text)
+		}
 	}
 }
 

--- a/internal/changeset/service.go
+++ b/internal/changeset/service.go
@@ -1294,19 +1294,26 @@ func digestFiles(files []FileChange) string {
 func unifiedDiff(files []FileChange) string {
 	var builder strings.Builder
 	for _, item := range files {
-		oldPath, newPath := "a/"+item.Path, "b/"+item.Path
-		oldContent, newContent := item.Original, item.Proposed
-		switch item.Operation {
-		case "create":
-			oldPath = "/dev/null"
-		case "delete":
-			newPath = "/dev/null"
-		case "rename":
-			newPath, newContent = "b/"+item.NewPath, item.Original
-		}
-		builder.WriteString(diffFile(oldPath, newPath, oldContent, newContent))
+		builder.WriteString(UnifiedDiffForFile(item))
 	}
 	return builder.String()
+}
+
+// UnifiedDiffForFile returns the displayable Unified Diff for one file change.
+// It is shared by the Changeset result and its per-file UI presentation so
+// both views describe the same proposed content.
+func UnifiedDiffForFile(item FileChange) string {
+	oldPath, newPath := "a/"+item.Path, "b/"+item.Path
+	oldContent, newContent := item.Original, item.Proposed
+	switch item.Operation {
+	case "create":
+		oldPath = "/dev/null"
+	case "delete":
+		newPath = "/dev/null"
+	case "rename":
+		newPath, newContent = "b/"+item.NewPath, item.Original
+	}
+	return diffFile(oldPath, newPath, oldContent, newContent)
 }
 
 func diffFile(oldPath, newPath string, oldContent, newContent []byte) string {

--- a/internal/server/acceptance_protocol_test.go
+++ b/internal/server/acceptance_protocol_test.go
@@ -247,11 +247,12 @@ func TestA01A02A03A07A10A13ViaMCPProtocol(t *testing.T) {
 			result, _ := mcpx["result"].(map[string]any)
 			status := "ok"
 			okValue := true
+			hints, _ := result["hints"].(map[string]any)
 			if result["type"] == "error" {
 				status, okValue = "error", false
-				if hints, _ := result["hints"].(map[string]any); hints["preferred_behavior"] == "ask_confirm" {
-					status = "need_confirmation"
-				}
+			}
+			if hints["preferred_behavior"] == "ask_confirm" {
+				status, okValue = "need_confirmation", false
 			}
 			normalized := map[string]any{"ok": okValue, "status": status, "data": result["data"], "_arc": envelope, "_result": res, "_text": text.Text}
 			if resultData, ok := result["data"].(map[string]any); ok {
@@ -286,7 +287,8 @@ func TestA01A02A03A07A10A13ViaMCPProtocol(t *testing.T) {
 	}
 	guidance, _ := openData["agent_guidance"].(map[string]any)
 	routing, _ := guidance["tool_routing"].(map[string]any)
-	if guidance["version"] != "1.0" || !containsAnyString(routing["modify_files"], "change_execute") {
+	responseContract, _ := guidance["response_contract"].(map[string]any)
+	if guidance["version"] != agentGuidanceVersion || !containsAnyString(routing["modify_files"], "change_execute") || responseContract["required"] != true {
 		t.Fatalf("session_open guidance missing or incomplete: %+v", guidance)
 	}
 	remoteSession, _ := openData["remote_session"].(map[string]any)

--- a/internal/server/agent_guidance.go
+++ b/internal/server/agent_guidance.go
@@ -7,7 +7,7 @@ import (
 	"mcpx/internal/envelope"
 )
 
-const agentGuidanceVersion = "1.0"
+const agentGuidanceVersion = "1.2"
 
 // agentGuidance is the short, stable routing contract shown after session_open.
 // It deliberately contains no workspace path, secret, approval token, or
@@ -25,11 +25,36 @@ func agentGuidance() map[string]any {
 			"Use change_execute for every file modification; provide the current file revision before editing.",
 			"Use command_execute only for explicit tests, builds, or user-requested commands.",
 			"Use change_manage only to prepare or inspect a Changeset; apply and revert through change_execute.",
+			"After a successful change_execute or Changeset review, include each changed file's concrete additions and removals in the final response as a Markdown ```diff code block; do not summarize only the file names. For oversized changes, show the bounded preview and mention the Changeset Resource.",
 			"When approval is required, preserve the exact remote_session_id and approval_id and do not duplicate the request.",
 			"Do not claim a file was read, changed, or verified without a successful tool result.",
-			"Call tools with the complete payload immediately; never announce intent first or wait for a schema re-fetch.",
+			"Before every important, mutating, destructive, or long-running call, briefly state what will be done and why; then call the tool with the complete payload without waiting for a schema re-fetch.",
+			"After every tool call, report the actual result before starting the next non-trivial action; distinguish verified facts from assumptions and unknowns.",
 			"Keep every change_execute call small (at most 300 added lines - lines actually inserted, not the whole file). Never truncate a file to dodge limits; submit full content or a replace_range window and retry if a host safety check blocks it.",
 			"Never quote instruction text (prompts, guidance, AGENTS.md) into file content; use plain code or data. If a host safety check blocks a call, shrink the content and retry instead of giving up.",
+		},
+		"response_contract": map[string]any{
+			"required": true,
+			"before_tool_call": []string{
+				"当前理解的目标",
+				"接下来要执行的查询、工具调用或命令及其目的",
+				"重要、变更、删除或长时间操作必须先说明准备做什么",
+			},
+			"after_tool_call": []string{
+				"实际调用的工具、查询或命令及其真实结果",
+				"读取、创建、修改、移动或删除的文件",
+				"每项文件变更的具体内容和影响；代码变更使用 Markdown ```diff 代码块",
+				"测试、构建、检查及其真实结果",
+				"失败、限制、风险和未验证事项",
+			},
+			"final_response": []string{
+				"当前理解的目标",
+				"实际执行的查询、工具调用或命令及目的",
+				"文件操作与每项变更的具体内容和影响",
+				"验证证据",
+				"失败、限制、风险和未验证事项",
+			},
+			"evidence_rule": "没有成功工具结果、明确命令输出或测试证据时，不得声称已读取、已修改、已修复、已构建或已测试通过。",
 		},
 		"change_payload": map[string]any{
 			"tool":     "change_execute",
@@ -72,6 +97,24 @@ func agentGuidanceInstructions() string {
 	}
 	for _, rule := range rules {
 		lines = append(lines, "- "+rule)
+	}
+	if contract, ok := guidance["response_contract"].(map[string]any); ok {
+		lines = append(lines, "", "Required user-visible response contract:")
+		if required, ok := contract["before_tool_call"].([]string); ok {
+			lines = append(lines, "- Before important tool calls:")
+			for _, item := range required {
+				lines = append(lines, "  - "+item)
+			}
+		}
+		if required, ok := contract["after_tool_call"].([]string); ok {
+			lines = append(lines, "- After every tool call:")
+			for _, item := range required {
+				lines = append(lines, "  - "+item)
+			}
+		}
+		if evidence, ok := contract["evidence_rule"].(string); ok {
+			lines = append(lines, "- Evidence rule: "+evidence)
+		}
 	}
 	if payload, ok := guidance["change_payload"].(map[string]any); ok {
 		lines = append(lines, "", "change_execute payload cheat-sheet (fallback if the tool schema is unavailable):")

--- a/internal/server/agent_guidance_test.go
+++ b/internal/server/agent_guidance_test.go
@@ -33,6 +33,24 @@ func TestAgentGuidanceUsesDedicatedRoutingWithoutBusinessArguments(t *testing.T)
 	}
 }
 
+func TestAgentGuidanceRequiresUserVisibleResponseContract(t *testing.T) {
+	guidance := agentGuidance()
+	contract, ok := guidance["response_contract"].(map[string]any)
+	if !ok || contract["required"] != true {
+		t.Fatalf("response contract = %+v", guidance["response_contract"])
+	}
+	for _, field := range []string{"before_tool_call", "after_tool_call", "final_response"} {
+		items, ok := contract[field].([]string)
+		if !ok || len(items) == 0 {
+			t.Fatalf("response contract field %q = %+v", field, contract[field])
+		}
+	}
+	evidence, _ := contract["evidence_rule"].(string)
+	if !strings.Contains(evidence, "不得声称") || !strings.Contains(evidence, "工具结果") {
+		t.Fatalf("evidence rule = %q", evidence)
+	}
+}
+
 func TestEveryPublicToolHasModelFacingDescriptionAndActionBranches(t *testing.T) {
 	runtime := &Runtime{}
 	protocol := mcpserver.NewMCPServer("mcpx-test", "0.1.0")
@@ -99,14 +117,17 @@ func TestAgentGuidanceIncludesChangePayloadCheatSheet(t *testing.T) {
 	}
 	rules, _ := guidance["rules"].([]string)
 	joined := strings.Join(rules, "\n")
-	if !strings.Contains(joined, "complete payload immediately") || !strings.Contains(joined, "300 added lines") {
-		t.Fatalf("rules must carry immediate-call and chunked-write guidance: %s", joined)
+	if !strings.Contains(joined, "complete payload") || !strings.Contains(joined, "300 added lines") {
+		t.Fatalf("rules must carry call and chunked-write guidance: %s", joined)
 	}
 	if !strings.Contains(joined, "host safety check blocks") || !strings.Contains(joined, "Never quote instruction text") {
 		t.Fatalf("rules must carry host-block recovery guidance: %s", joined)
 	}
+	if !strings.Contains(joined, "concrete additions and removals") || !strings.Contains(joined, "Markdown ```diff code block") {
+		t.Fatalf("rules must carry final Markdown diff guidance: %s", joined)
+	}
 	instructions := agentGuidanceInstructions()
-	if !strings.Contains(instructions, "change_execute payload cheat-sheet") || !strings.Contains(instructions, "insert_after") {
+	if !strings.Contains(instructions, "Required user-visible response contract") || !strings.Contains(instructions, "change_execute payload cheat-sheet") || !strings.Contains(instructions, "insert_after") {
 		t.Fatalf("instructions must render the cheat-sheet: %s", instructions)
 	}
 }

--- a/internal/server/tools_change_execute.go
+++ b/internal/server/tools_change_execute.go
@@ -143,7 +143,7 @@ func (r *Runtime) toolChangeExecute(ctx context.Context, req mcp.CallToolRequest
 	}
 
 	if !apply {
-		out := changeDiffResultFromDTO(session.WorkspacePath, prepared, resultPayload)
+		out := changeDiffResultFromDTO(prepared, resultPayload)
 		return out, nil
 	}
 
@@ -165,12 +165,10 @@ func (r *Runtime) toolChangeExecute(ctx context.Context, req mcp.CallToolRequest
 		if approvalErr != nil {
 			return r.terminalError(envReq, session.ID, session.WorkspaceName, "approval_store_error", approvalErr.Error())
 		}
+		resultPayload["approval_id"] = approvalID
+		resultPayload["next_action"] = nextAction("approval_manage", map[string]any{"remote_session_id": session.ID, "action": "approve", "approval_id": approvalID})
 		response := envelope.Fail(envelope.StatusNeedConfirmation, envReq.RequestID, session.WorkspaceName,
-			map[string]any{
-				"approval_id": approvalID, "changeset_id": prepared.ID, "digest": prepared.Digest,
-				"diff":        resultPayload["diff"],
-				"next_action": nextAction("approval_manage", map[string]any{"remote_session_id": session.ID, "action": "approve", "approval_id": approvalID}),
-			}, "APPROVAL_REQUIRED", "source change requires approval")
+			resultPayload, "APPROVAL_REQUIRED", "source change requires approval")
 		response.RemoteSessionID = session.ID
 		return r.resultJSON(response)
 	}
@@ -196,7 +194,7 @@ func (r *Runtime) toolChangeExecute(ctx context.Context, req mcp.CallToolRequest
 		resultPayload["verify"] = verifyResults
 	}
 
-	return changeDiffResultFromDTO(session.WorkspacePath, prepared, resultPayload), nil
+	return changeDiffResultFromDTO(prepared, resultPayload), nil
 }
 
 func (r *Runtime) patchTooLargeResult(envReq envelope.Request, session remotesession.Session, changedLines, maxLines int) (*mcp.CallToolResult, error) {
@@ -229,7 +227,7 @@ func (r *Runtime) executePreparedChange(ctx context.Context, envReq envelope.Req
 		return r.changeError(envReq, session.ID, session.WorkspaceName, fmt.Errorf("changeset digest mismatch for %s", path))
 	}
 	if apply, exists := envReq.Payload["apply"].(bool); exists && !apply {
-		return changeDiffResult(session.WorkspacePath, item), nil
+		return changeDiffResult(item), nil
 	}
 	return r.applyPreparedChange(ctx, envReq, principal, session, item, "change_execute")
 }
@@ -255,7 +253,7 @@ func (r *Runtime) executeRevertChange(ctx context.Context, envReq envelope.Reque
 	}
 	_ = r.remote.AddEvent(ctx, principal, remotesession.Event{RemoteSessionID: session.ID, Type: "changeset.revert_prepared", OperationID: revert.ID, Summary: revert.Summary})
 	if apply, exists := envReq.Payload["apply"].(bool); exists && !apply {
-		return changeDiffResult(session.WorkspacePath, revert), nil
+		return changeDiffResult(revert), nil
 	}
 	return r.applyPreparedChange(ctx, envReq, principal, session, revert, "change_execute")
 }
@@ -311,7 +309,7 @@ func (r *Runtime) replayChangeExecute(envReq envelope.Request, session remoteses
 			return result
 		}
 	}
-	return changeDiffResultFromDTO(session.WorkspacePath, item, payload)
+	return changeDiffResultFromDTO(item, payload)
 }
 
 func formatSourceContent(ctx context.Context, workspacePath string, content []byte) ([]byte, error) {

--- a/internal/server/tools_change_recovery_test.go
+++ b/internal/server/tools_change_recovery_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 
+	"mcpx/internal/changeset"
 	"mcpx/internal/remotesession"
 )
 
-func TestChangeExecutePersistsDiffFile(t *testing.T) {
+func TestChangeExecuteDoesNotWriteDiffFileToWorkspace(t *testing.T) {
 	rt := newWorkspaceRuntime(t, "demo")
 	principal, err := rt.principalFromContext(context.Background())
 	if err != nil {
@@ -33,7 +34,7 @@ func TestChangeExecutePersistsDiffFile(t *testing.T) {
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"remote_session_id": created.Session.ID,
-		"summary":           "persist diff",
+		"summary":           "return diff without workspace artifact",
 		"operations": []map[string]any{
 			{"operation": "create", "path": "hello.go", "content": "package demo\n\nconst Hello = 1\n"},
 		},
@@ -44,12 +45,36 @@ func TestChangeExecutePersistsDiffFile(t *testing.T) {
 	}
 	response := decodeToolResult(t, result)
 	data, _ := response["data"].(map[string]any)
-	diffFile, _ := data["diff_file"].(string)
-	if !strings.HasPrefix(diffFile, ".mcpx/diffs/") || !strings.HasSuffix(diffFile, ".diff") {
-		t.Fatalf("change result must expose a persisted diff file: %+v", data)
+	if _, exists := data["diff_file"]; exists {
+		t.Fatalf("change result must not expose a workspace diff file: %+v", data)
 	}
-	if _, err := os.Stat(filepath.Join(registered.Path, filepath.FromSlash(diffFile))); err != nil {
-		t.Fatalf("persisted diff file missing: %v", err)
+	if _, err := os.Stat(filepath.Join(registered.Path, ".mcpx")); !os.IsNotExist(err) {
+		t.Fatalf("change execution must not create workspace .mcpx artifacts: %v", err)
+	}
+}
+
+func TestChangeSummaryIncludesPerFileDiffPreview(t *testing.T) {
+	item := changeset.Changeset{
+		ID: "chg_preview",
+		Files: []changeset.FileChange{{
+			Operation: "update",
+			Path:      "ChatGPT-互联网医院小程序修复.txt",
+			Original:  []byte("旧消息链路\n"),
+			Proposed:  []byte("新消息链路\n"),
+		}},
+	}
+
+	dto := changeSummaryDTO(item)
+	files, ok := dto["files"].([]map[string]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("per-file DTO missing: %+v", dto["files"])
+	}
+	if files[0]["path"] != item.Files[0].Path {
+		t.Fatalf("per-file path = %v", files[0]["path"])
+	}
+	diff, _ := files[0]["diff"].(string)
+	if !strings.Contains(diff, "-旧消息链路") || !strings.Contains(diff, "+新消息链路") {
+		t.Fatalf("per-file diff preview must include concrete changes: %q", diff)
 	}
 }
 

--- a/internal/server/tools_changeset.go
+++ b/internal/server/tools_changeset.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -51,7 +50,7 @@ func (r *Runtime) toolChangePrepare(ctx context.Context, req mcp.CallToolRequest
 		return r.changeError(envReq, session.ID, session.WorkspaceName, err)
 	}
 	_ = r.remote.AddEvent(ctx, principal, remotesession.Event{RemoteSessionID: session.ID, Type: "changeset.prepared", OperationID: prepared.ID, Summary: prepared.Summary})
-	return changeDiffResult(session.WorkspacePath, prepared), nil
+	return changeDiffResult(prepared), nil
 }
 
 func (r *Runtime) toolChangeDiff(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -67,7 +66,7 @@ func (r *Runtime) toolChangeDiff(ctx context.Context, req mcp.CallToolRequest) (
 	if item.RemoteSessionID != session.ID {
 		return r.changeError(envReq, session.ID, session.WorkspaceName, changeset.ErrNotFound)
 	}
-	return changeDiffResult(session.WorkspacePath, item), nil
+	return changeDiffResult(item), nil
 }
 
 func (r *Runtime) toolChangeApply(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -106,11 +105,11 @@ func (r *Runtime) toolChangeApply(ctx context.Context, req mcp.CallToolRequest) 
 		if approvalErr != nil {
 			return r.terminalError(envReq, session.ID, session.WorkspaceName, "approval_store_error", approvalErr.Error())
 		}
+		approvalData := changeSummaryDTO(item)
+		approvalData["approval_id"] = approvalID
+		approvalData["next_action"] = nextAction("approval_manage", map[string]any{"remote_session_id": session.ID, "action": "approve", "approval_id": approvalID})
 		response := envelope.Fail(envelope.StatusNeedConfirmation, envReq.RequestID, session.WorkspaceName,
-			map[string]any{
-				"approval_id": approvalID, "changeset_id": item.ID, "digest": item.Digest,
-				"next_action": nextAction("approval_manage", map[string]any{"remote_session_id": session.ID, "action": "approve", "approval_id": approvalID}),
-			}, "APPROVAL_REQUIRED", "Changeset apply requires approval")
+			approvalData, "APPROVAL_REQUIRED", "Changeset apply requires approval")
 		response.RemoteSessionID = session.ID
 		return r.resultJSON(response)
 	}
@@ -154,7 +153,7 @@ func (r *Runtime) toolChangeRevert(ctx context.Context, req mcp.CallToolRequest)
 		return r.changeError(envReq, session.ID, session.WorkspaceName, err)
 	}
 	_ = r.remote.AddEvent(ctx, principal, remotesession.Event{RemoteSessionID: session.ID, Type: "changeset.revert_prepared", OperationID: revert.ID, Summary: revert.Summary})
-	return changeDiffResult(session.WorkspacePath, revert), nil
+	return changeDiffResult(revert), nil
 }
 
 func (r *Runtime) changeRequest(ctx context.Context, req mcp.CallToolRequest, edit bool) (envelope.Request, auth.Principal, remotesession.Session, *mcp.CallToolResult) {
@@ -208,38 +207,35 @@ func parseChangeOperations(value any) ([]changeset.Operation, error) {
 }
 
 const (
-	diffInlineMaxBytes = 256 << 10 // 256 KiB inline budget
-	diffPreviewLines   = 100
+	diffInlineMaxBytes       = 256 << 10 // 256 KiB inline budget
+	diffPreviewLines         = 100
+	diffFilePreviewMaxBytes  = 32 << 10 // 32 KiB per-file UI preview budget
+	diffFilesPreviewMaxBytes = 64 << 10 // 64 KiB aggregate per-file UI preview budget
 )
-
-// changesetDiffsDir is the workspace-relative directory for persisted diffs.
-const changesetDiffsDir = ".mcpx/diffs"
-
-// writeChangesetDiffFile persists the complete Unified Diff under the
-// workspace so hosts and users can open it directly and file_read can resume
-// it. Failures are silent: the change result must not depend on the file.
-func writeChangesetDiffFile(workspacePath string, item changeset.Changeset) string {
-	if workspacePath == "" || item.UnifiedDiff == "" || item.ID == "" {
-		return ""
-	}
-	dir := filepath.Join(workspacePath, filepath.FromSlash(changesetDiffsDir))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return ""
-	}
-	if err := os.WriteFile(filepath.Join(dir, item.ID+".diff"), []byte(item.UnifiedDiff), 0o644); err != nil {
-		return ""
-	}
-	return changesetDiffsDir + "/" + item.ID + ".diff"
-}
 
 func changeSummaryDTO(item changeset.Changeset) map[string]any {
 	files := make([]map[string]any, 0, len(item.Files))
+	previewBudget := diffFilesPreviewMaxBytes
 	for _, f := range item.Files {
-		files = append(files, map[string]any{
+		file := map[string]any{
 			"path": f.Path, "new_path": f.NewPath, "operation": f.Operation,
 			"original_sha256": f.OriginalSHA256, "proposed_sha256": f.ProposedSHA256,
 			"expected_sha256": f.ExpectedSHA256,
-		})
+		}
+		if previewBudget > 0 {
+			fileBudget := diffFilePreviewMaxBytes
+			if previewBudget < fileBudget {
+				fileBudget = previewBudget
+			}
+			if preview, truncated := fileDiffPreview(f, fileBudget); preview != "" {
+				file["diff"] = preview
+				previewBudget -= len(preview)
+				if truncated {
+					file["diff_truncated"] = true
+				}
+			}
+		}
+		files = append(files, file)
 	}
 	diffBytes := len(item.UnifiedDiff)
 	uri := fmt.Sprintf("mcpx://remote-sessions/%s/changesets/%s/diff", item.RemoteSessionID, item.ID)
@@ -262,35 +258,117 @@ func changeSummaryDTO(item changeset.Changeset) map[string]any {
 	}
 }
 
+func fileDiffPreview(item changeset.FileChange, maxBytes int) (string, bool) {
+	diff := changeset.UnifiedDiffForFile(item)
+	if diff == "" || maxBytes <= 0 {
+		return "", false
+	}
+	preview := trimDiffPreview(diff, diffPreviewLines)
+	if len(preview) <= maxBytes {
+		return preview, preview != diff
+	}
+	suffix := "\n... (file diff preview truncated; see the changeset diff resource)"
+	if maxBytes <= len(suffix) {
+		return suffix[:maxBytes], true
+	}
+	limit := maxBytes - len(suffix)
+	for limit > 0 && !utf8.ValidString(preview[:limit]) {
+		limit--
+	}
+	return preview[:limit] + suffix, true
+}
+
 func trimDiffPreview(diff string, maxLines int) string {
 	lines := strings.Split(diff, "\n")
 	if len(lines) <= maxLines {
 		return diff
 	}
-	return strings.Join(lines[:maxLines], "\n") + fmt.Sprintf("\n... (%d more lines; see the persisted diff file)", len(lines)-maxLines)
+	return strings.Join(lines[:maxLines], "\n") + fmt.Sprintf("\n... (%d more lines; see the changeset diff resource)", len(lines)-maxLines)
 }
 
-func changeDiffResult(workspacePath string, item changeset.Changeset) *mcp.CallToolResult {
-	return changeDiffResultFromDTO(workspacePath, item, changeSummaryDTO(item))
+func changeDiffResult(item changeset.Changeset) *mcp.CallToolResult {
+	return changeDiffResultFromDTO(item, changeSummaryDTO(item))
 }
 
-func changeDiffResultFromDTO(workspacePath string, item changeset.Changeset, dto map[string]any) *mcp.CallToolResult {
-	if rel := writeChangesetDiffFile(workspacePath, item); rel != "" {
-		dto["diff_file"] = rel
-	}
+func changeDiffResultFromDTO(item changeset.Changeset, dto map[string]any) *mcp.CallToolResult {
 	diffMeta, _ := dto["diff"].(map[string]any)
 	mode, _ := diffMeta["mode"].(string)
 	fallback := fmt.Sprintf("Changeset %s digest=%s files=%d diff_mode=%s", item.ID, item.Digest, len(item.Files), mode)
-	// content is a model-facing summary; the complete diff stays inline in
-	// structuredContent (up to the inline budget) or as a bounded preview for
-	// oversized diffs. No file resource is attached to the conversation.
-	result := mcp.NewToolResultStructured(dto, fallback)
-	if mode == "resource" {
-		preview, _ := diffMeta["unified_diff_preview"].(string)
-		summary := fallback + "\n\n```diff\n" + preview + "\n```"
-		result = mcp.NewToolResultStructured(dto, summary)
+	// Keep the first text content useful even for hosts that do not consume
+	// ARC structuredContent. The public wrapper renders the same data again,
+	// while direct MCP clients still receive a Markdown diff in the session.
+	if markdown := changesetDiffMarkdown(dto); markdown != "" {
+		fallback += "\n\n" + markdown
 	}
-	return result
+	return mcp.NewToolResultStructured(dto, fallback)
+}
+
+func changesetDiffMarkdown(dto map[string]any) string {
+	files := changesetResultFiles(dto["files"])
+	var builder strings.Builder
+	truncated := false
+	for _, file := range files {
+		diff, _ := file["diff"].(string)
+		path, _ := file["path"].(string)
+		if strings.TrimSpace(diff) == "" || path == "" {
+			continue
+		}
+		label := path
+		if newPath, _ := file["new_path"].(string); newPath != "" && newPath != path {
+			label += " → " + newPath
+		}
+		op, _ := file["operation"].(string)
+		fmt.Fprintf(&builder, "#### `%s`", label)
+		if op != "" {
+			builder.WriteString(" · ")
+			builder.WriteString(op)
+		}
+		builder.WriteString("\n\n```diff\n")
+		builder.WriteString(diff)
+		builder.WriteString("\n```")
+		if value, _ := file["diff_truncated"].(bool); value {
+			truncated = true
+		}
+	}
+	if builder.Len() > 0 {
+		diffMeta, _ := dto["diff"].(map[string]any)
+		if diffMeta["mode"] == "resource" {
+			truncated = true
+		}
+		if truncated {
+			if resourceURI, _ := diffMeta["resource_uri"].(string); resourceURI != "" {
+				builder.WriteString("\n\n> 完整变更见 Changeset Resource。")
+			}
+		}
+		return builder.String()
+	}
+
+	diffMeta, _ := dto["diff"].(map[string]any)
+	diff, _ := diffMeta["unified_diff"].(string)
+	if diff == "" {
+		diff, _ = diffMeta["unified_diff_preview"].(string)
+	}
+	if diff == "" {
+		return ""
+	}
+	return "```diff\n" + trimDiffPreview(diff, diffPreviewLines) + "\n```"
+}
+
+func changesetResultFiles(value any) []map[string]any {
+	switch files := value.(type) {
+	case []map[string]any:
+		return files
+	case []any:
+		result := make([]map[string]any, 0, len(files))
+		for _, raw := range files {
+			if file, ok := raw.(map[string]any); ok {
+				result = append(result, file)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
 }
 
 func (r *Runtime) changeError(envReq envelope.Request, remoteSessionID, workspace string, err error) (*mcp.CallToolResult, error) {

--- a/internal/server/tools_remote_session_test.go
+++ b/internal/server/tools_remote_session_test.go
@@ -224,8 +224,8 @@ func TestChangesetMCPDiffAndApprovalSurviveTransportChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := preparedResult.Content[0].(mcp.TextContent).Text
-	if strings.Contains(text, "Value = 2") || !strings.Contains(text, "Changeset") {
-		t.Fatalf("content should be a concise diff summary:\n%s", text)
+	if !strings.Contains(text, "```diff") || !strings.Contains(text, "Value = 2") || !strings.Contains(text, "demo.go") {
+		t.Fatalf("content should include a Markdown diff with the changed file:\n%s", text)
 	}
 	preparedDTO, ok := preparedResult.StructuredContent.(map[string]any)
 	if !ok {
@@ -262,6 +262,15 @@ func TestChangesetMCPDiffAndApprovalSurviveTransportChange(t *testing.T) {
 	}
 	pendingData := pending["data"].(map[string]any)
 	approvalID := pendingData["approval_id"].(string)
+	pendingFiles, _ := pendingData["files"].([]any)
+	if len(pendingFiles) != 1 {
+		t.Fatalf("approval response must include changed files: %+v", pendingData)
+	}
+	pendingFile, _ := pendingFiles[0].(map[string]any)
+	pendingDiff, _ := pendingFile["diff"].(string)
+	if !strings.Contains(pendingDiff, "-const Value = 1") || !strings.Contains(pendingDiff, "+const Value = 2") {
+		t.Fatalf("approval response must include concrete file diff: %+v", pendingFile)
+	}
 	missingSession := callEnvelope(t, runtime.toolApprovalConfirm, contextFor("transport-confirm-missing"), map[string]any{
 		"approval_id": approvalID,
 		"approve":     true,


### PR DESCRIPTION
修复代码变更结果只显示文件名且在 workspace 生成 Diff 文件的问题。

- 在 MCP/ARC 结果中按文件返回 Markdown Diff
- 增加会话响应契约，要求报告目标、操作、文件、验证和风险
- 将完整 Diff 保留在 Changeset Resource，移除 workspace 落盘
- 覆盖审批路径并补充回归测试

验证：go test ./... -count=1；go vet ./...；CGO_ENABLED=0 go build