### PR TITLE
fix(session): 支持会话恢复发现

### DIFF
--- a/internal/remotesession/service.go
+++ b/internal/remotesession/service.go
@@ -258,9 +258,9 @@ func (s *Service) List(ctx context.Context, principal auth.Principal, in ListInp
 		args = append(args, in.Workspace)
 	}
 	if in.Query != "" {
-		query += " AND (rs.label LIKE ? OR rs.description LIKE ?)"
+		query += " AND (rs.id LIKE ? OR rs.label LIKE ? OR rs.description LIKE ?)"
 		like := "%" + in.Query + "%"
-		args = append(args, like, like)
+		args = append(args, like, like, like)
 	}
 	if len(in.Statuses) > 0 {
 		query += " AND rs.status IN (" + placeholders(len(in.Statuses)) + ")"

--- a/internal/server/guidance/agent.yaml
+++ b/internal/server/guidance/agent.yaml
@@ -3,6 +3,7 @@ priority: high
 summary: 使用 MCPX 的结构化工具完成开发工作；模型负责工程判断，Runtime 负责协议、安全、恢复与观测。
 rules:
   - 工具的 structuredContent 是机器事实来源；remote_session_id、plan_id、plan_task_id、execution_task_id、operation_id、artifact_id、sha256、revision 和 confirmation token 必须从服务端结果原样复用，不要从展示文本解析或凭记忆重建。
+  - remote_session_id 丢失、未知或返回 not_found 时，先调用 session(action=list，可带 workspace/query/status) 发现已有 Remote Session；根据 workspace、label、status 和 last_active_at 识别目标，再用返回的完整 remote_session_id 调用 session(action=open) 恢复，不要通过新建 Session 假装 resume。
   - 不要猜测路径、API、符号、ID、revision、工具能力或执行结果；先用对应的只读工具取得证据。没有成功工具结果或验证证据时，不得声称已读取、修改、修复、构建或测试通过。
   - 每种语义使用唯一 canonical tool：源码/文件读取用 read，环境事实用 environment_read，文件变更用 edit，删除/移出用 move_out，命令/测试/构建用 execute，Session/Task/Plan/历史/日志用 observe；不要用 execute 代替文件或环境读取。
   - 修改前取得足够的当前证据并保留用户未要求的现有变更；只提交完成目标所需的最小改动。update/rename 使用服务端返回的最新 base_sha256，保持原文件编码、BOM、换行和末尾换行。

--- a/internal/server/tools_clean_core.go
+++ b/internal/server/tools_clean_core.go
@@ -111,8 +111,12 @@ func (r *Runtime) registerCleanCoreTools(s *mcp.Server) {
 
 	r.addTool(s, cleanCoreTool("session", desc["session"], map[string]any{
 		"remote_session_id":            remoteSession,
-		"action":                       enumSchema("会话生命周期动作；省略时默认 open/resume，传 mode 时可省略并推导 close", "open", "close"),
+		"action":                       enumSchema("会话生命周期动作；省略时默认 open/resume，传 mode 时可省略并推导 close；remote_session_id 丢失时显式 list 发现已有会话", "open", "list", "close"),
 		"workspace":                    workspace,
+		"query":                        stringSchema("list 时按 label、description 或 Session ID 搜索"),
+		"status":                       stringSchema("list 时按状态过滤；多个状态用逗号分隔"),
+		"cursor":                       stringSchema("list 分页游标"),
+		"limit":                        numberSchema("list 返回数量限制"),
 		"label":                        stringSchema("会话标签"),
 		"description":                  stringSchema("开发目标或会话描述"),
 		"client_request_id":            stringSchema("客户端幂等键"),

--- a/internal/server/tools_public_adapters.go
+++ b/internal/server/tools_public_adapters.go
@@ -43,6 +43,8 @@ func (r *Runtime) toolSession(ctx context.Context, req *mcp.CallToolRequest) (*m
 	switch action {
 	case "open":
 		return r.toolSessionOpen(ctx, req)
+	case "list":
+		return r.toolRemoteSessionList(ctx, req)
 	case "close":
 		return r.toolRemoteSessionClose(ctx, req)
 	default:
@@ -50,7 +52,7 @@ func (r *Runtime) toolSession(ctx context.Context, req *mcp.CallToolRequest) (*m
 		if fail != nil {
 			return fail, nil
 		}
-		return r.terminalError(envReq, envReq.RemoteSessionID, envReq.Workspace, "bad_request", "action must be open or close")
+		return r.terminalError(envReq, envReq.RemoteSessionID, envReq.Workspace, "bad_request", "action must be open, list, or close")
 	}
 }
 

--- a/internal/server/tools_remote_session.go
+++ b/internal/server/tools_remote_session.go
@@ -102,7 +102,7 @@ func (r *Runtime) remoteError(envReq envelope.Request, remoteSessionID, workspac
 	}
 	message := err.Error()
 	if code == "not_found" {
-		message = "remote session not found：remote_session_id 必须原样复制 session 返回的完整值，不能改写、缩写或凭记忆重输。"
+		message = "remote session not found：remote_session_id 必须原样复制 session 返回的完整值。如果 ID 已丢失或不确定，先调用 session(action=list) 发现已有会话，再用返回的完整 remote_session_id 调用 session(action=open) 恢复；不要直接创建新 Session。"
 	}
 	resp := envelope.Fail(status, envReq.RequestID, workspace, nil, code, message)
 	resp.RemoteSessionID = remoteSessionID
@@ -115,7 +115,11 @@ func (r *Runtime) remoteError(envReq envelope.Request, remoteSessionID, workspac
 		)
 	case "not_found":
 		if remoteSessionID != "" {
-			addRecoveryAction(&resp, "workspace", "refresh workspace selection before opening a new Remote Session", map[string]any{})
+			arguments := map[string]any{"action": "list"}
+			if workspace = strings.TrimSpace(workspace); workspace != "" {
+				arguments["workspace"] = workspace
+			}
+			addRecoveryAction(&resp, "session", "discover an existing Remote Session before opening a new one", arguments)
 		}
 	case "remote_session_required":
 		if workspace != "" {
@@ -156,6 +160,34 @@ func (r *Runtime) createRemoteSession(ctx context.Context, principal auth.Princi
 		r.logAudit(audit.Event{RequestID: envReq.RequestID, RemoteSessionID: result.Session.ID, Workspace: workspaceName, Tool: "workspace_baseline", Status: "error", Detail: map[string]any{"error": err.Error()}})
 	}
 	return result, nil
+}
+
+func (r *Runtime) toolRemoteSessionList(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	envReq, principal, fail := r.remoteRequest(ctx, req)
+	if fail != nil {
+		return fail, nil
+	}
+	workspaceName := strings.TrimSpace(envReq.Workspace)
+	if workspaceName == "" {
+		workspaceName, _ = envReq.Payload["workspace"].(string)
+	}
+	query, _ := envReq.Payload["query"].(string)
+	status, _ := envReq.Payload["status"].(string)
+	cursor, _ := envReq.Payload["cursor"].(string)
+	limit := intPayload(envReq.Payload, "limit")
+	var statuses []string
+	for _, value := range strings.Split(status, ",") {
+		if value = strings.TrimSpace(value); value != "" {
+			statuses = append(statuses, value)
+		}
+	}
+	result, err := r.remote.List(ctx, principal, remotesession.ListInput{
+		Workspace: workspaceName, Query: query, Statuses: statuses, Limit: limit, Cursor: cursor,
+	})
+	if err != nil {
+		return r.remoteError(envReq, "", workspaceName, err)
+	}
+	return r.remoteResult(envReq, "", workspaceName, result)
 }
 
 func (r *Runtime) toolRemoteSessionClose(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/server/tools_remote_session_test.go
+++ b/internal/server/tools_remote_session_test.go
@@ -163,9 +163,54 @@ func TestRemoteSessionNotFoundExplainsExactCopy(t *testing.T) {
 		t.Fatalf("missing session error = %+v", response)
 	}
 	message, _ := errorBody["message"].(string)
-	for _, phrase := range []string{"原样复制", "session"} {
+	for _, phrase := range []string{"原样复制", "session(action=list)", "不要直接创建新 Session"} {
 		if !strings.Contains(message, phrase) {
 			t.Fatalf("missing session error must explain %q: %s", phrase, message)
 		}
+	}
+	recovery, _ := errorBody["recovery"].(map[string]any)
+	arguments, _ := recovery["arguments"].(map[string]any)
+	if recovery["tool"] != "session" || arguments["action"] != "list" {
+		t.Fatalf("missing session recovery must point to session list: %+v", recovery)
+	}
+}
+
+func TestCleanCoreSessionListDiscoversExistingSession(t *testing.T) {
+	rt := newWorkspaceRuntime(t, "demo")
+	opened := callEnvelope(t, rt.toolSession, context.Background(), map[string]any{
+		"action": "open", "workspace": "demo", "label": "recover-me",
+	})
+	remoteID, _ := opened["remote_session_id"].(string)
+	if remoteID == "" {
+		t.Fatalf("session open did not return remote_session_id: %+v", opened)
+	}
+
+	listed := callEnvelope(t, rt.toolSession, context.Background(), map[string]any{
+		"action": "list", "workspace": "demo", "query": "recover-me",
+	})
+	if !statusOK(listed) {
+		t.Fatalf("session list failed: %+v", listed)
+	}
+	data, _ := listed["data"].(map[string]any)
+	sessions, _ := data["sessions"].([]any)
+	if len(sessions) != 1 {
+		t.Fatalf("session list returned %d sessions: %+v", len(sessions), data)
+	}
+	item, _ := sessions[0].(map[string]any)
+	if item["remote_session_id"] != remoteID || item["workspace"] != "demo" || item["label"] != "recover-me" {
+		t.Fatalf("session list did not return the recoverable session: %+v", item)
+	}
+	lastActive, _ := item["last_active_at"].(string)
+	if strings.TrimSpace(lastActive) == "" {
+		t.Fatalf("session list must expose last_active_at for recovery selection: %+v", item)
+	}
+
+	byID := callEnvelope(t, rt.toolSession, context.Background(), map[string]any{
+		"action": "list", "workspace": "demo", "query": remoteID,
+	})
+	idData, _ := byID["data"].(map[string]any)
+	idSessions, _ := idData["sessions"].([]any)
+	if len(idSessions) != 1 {
+		t.Fatalf("session list must support ID lookup: %+v", idData)
 	}
 }


### PR DESCRIPTION
# PR：支持 Remote Session 发现与恢复

## 描述

### 变更内容

- 为 Remote Session 增加 `ListForPrincipal`
- `session` 增加 `action=list`
- 支持按 workspace、query、status 查找已有 Session
- `remote_session_id` 丢失或失效时，可先 list 再恢复原 Session
- 更新 Agent recovery guidance
- 不通过新建 Session 模拟 resume

### 背景

客户端丢失 `remote_session_id` 后，之前缺少可靠的 Session 发现入口，只能依赖客户端自己保存 ID。

这个 PR 补上 Session discovery，使恢复流程可以基于服务端已有 Session 完成。

### 验证

- `gofmt` ✅
- focused tests ✅
- `go test ./... -count=1` ✅
- `go test -race ./... -count=1` ✅
- `go vet ./...` ✅
- build ✅