### PR TITLE
fix(shell): 优先使用现代 Bash 并收紧命令缺失判定

### DIFF
--- a/internal/environment/inspect.go
+++ b/internal/environment/inspect.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"mcpx/internal/screenshot"
+	"mcpx/internal/terminal"
 	buildversion "mcpx/internal/version"
 )
 
@@ -243,10 +244,9 @@ func inspectExecution() *ExecutionInfo {
 }
 
 func inspectShell() *ShellInfo {
-	execution := "/bin/bash"
+	execution := terminal.ExecutionShell()
 	interactive := filepath.Base(os.Getenv("SHELL"))
 	if runtime.GOOS == "windows" {
-		execution = "cmd.exe"
 		interactive = filepath.Base(os.Getenv("COMSPEC"))
 	}
 	return &ShellInfo{ExecutionShell: execution, InteractiveShell: interactive}

--- a/internal/server/command_failure_test.go
+++ b/internal/server/command_failure_test.go
@@ -1,0 +1,18 @@
+package server
+
+import "testing"
+
+func TestCommandFailureCodeRecognizesExit127RegardlessOfLocale(t *testing.T) {
+	for _, stderr := range []string{
+		"bash: missing: command not found\n",
+		"/opt/homebrew/bin/bash: 行 1: missing: 未找到命令\n",
+		"",
+	} {
+		if got := commandFailureCode(127, stderr); got != "COMMAND_NOT_FOUND" {
+			t.Fatalf("commandFailureCode(127, %q) = %q", stderr, got)
+		}
+	}
+	if got := commandFailureCode(126, "command not found"); got != "PROCESS_EXIT" {
+		t.Fatalf("commandFailureCode(126, ...) = %q", got)
+	}
+}

--- a/internal/server/tools_command_execute.go
+++ b/internal/server/tools_command_execute.go
@@ -304,12 +304,12 @@ func commandIntent(req envelope.Request) (purpose, scope string, err error) {
 	return purpose, scope, nil
 }
 
-func commandFailureCode(exitCode int, stderr string) string {
+func commandFailureCode(exitCode int, _ string) string {
+	// POSIX shells reserve 127 for command lookup failure. Do not inspect the
+	// shell's diagnostic text here: modern Bash localizes that message, so an
+	// English substring check makes protocol error taxonomy locale-dependent.
 	if exitCode == 127 {
-		lower := strings.ToLower(stderr)
-		if strings.Contains(lower, "command not found") || strings.Contains(lower, "no such file or directory") {
-			return "COMMAND_NOT_FOUND"
-		}
+		return "COMMAND_NOT_FOUND"
 	}
 	return "PROCESS_EXIT"
 }

--- a/internal/terminal/exec.go
+++ b/internal/terminal/exec.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
-	"runtime"
 	"time"
 )
 
@@ -32,12 +31,7 @@ func Exec(ctx context.Context, opts ExecOptions) (Result, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "cmd", "/C", opts.Command)
-	} else {
-		cmd = exec.CommandContext(ctx, "/bin/bash", "-lc", opts.Command)
-	}
+	cmd := commandShell(ctx, opts.Command)
 	cmd.Dir = opts.WorkDir
 	if len(opts.ExtraEnv) > 0 {
 		cmd.Env = append(cmd.Environ(), opts.ExtraEnv...)

--- a/internal/terminal/shell.go
+++ b/internal/terminal/shell.go
@@ -1,0 +1,60 @@
+package terminal
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ExecutionShell returns the shell used for command-string execution.
+// MCPX command policy and command syntax are Bash-oriented on Unix, so this
+// deliberately resolves Bash rather than blindly executing the user's
+// interactive shell (which may be zsh, fish, etc.).
+func ExecutionShell() string {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe"
+	}
+
+	// Respect an explicitly selected Bash when SHELL already points at one.
+	// This is especially useful for Homebrew/MacPorts Bash installations.
+	if shell := strings.TrimSpace(os.Getenv("SHELL")); filepath.Base(shell) == "bash" && executableFile(shell) {
+		return shell
+	}
+
+	// macOS ships /bin/bash 3.2. Prefer common modern Bash installations before
+	// falling back to the system Bash. This avoids loading modern login-shell
+	// tooling (SDKMAN, etc.) under the obsolete system Bash.
+	if runtime.GOOS == "darwin" {
+		for _, candidate := range []string{"/opt/homebrew/bin/bash", "/usr/local/bin/bash"} {
+			if executableFile(candidate) {
+				return candidate
+			}
+		}
+	}
+
+	if candidate, err := exec.LookPath("bash"); err == nil && executableFile(candidate) {
+		return candidate
+	}
+	return "/bin/bash"
+}
+
+func commandShell(ctx context.Context, command string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/C", command)
+	}
+	return exec.CommandContext(ctx, ExecutionShell(), "-lc", command)
+}
+
+func executableFile(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}

--- a/internal/terminal/shell_test.go
+++ b/internal/terminal/shell_test.go
@@ -1,0 +1,35 @@
+package terminal
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestExecutionShellPrefersBashFromShellEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix shell resolution test")
+	}
+	dir := t.TempDir()
+	bash := filepath.Join(dir, "bash")
+	if err := os.WriteFile(bash, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(bash, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", bash)
+
+	if got := ExecutionShell(); got != bash {
+		t.Fatalf("ExecutionShell() = %q, want %q", got, bash)
+	}
+	cmd := commandShell(context.Background(), "printf ok")
+	if cmd.Path != bash {
+		t.Fatalf("command shell path = %q, want %q", cmd.Path, bash)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "-lc" || cmd.Args[2] != "printf ok" {
+		t.Fatalf("command shell args = %#v", cmd.Args)
+	}
+}

--- a/internal/terminal/task.go
+++ b/internal/terminal/task.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -175,12 +174,7 @@ func (m *TaskManager) StartRemoteWithObservationContext(ctx context.Context, req
 
 func (m *TaskManager) start(_ context.Context, requestID, callID, tool, remoteSessionID, workspaceName, workDir, command string) (*Task, error) {
 	ctx, cancel := context.WithCancel(context.Background())
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "cmd", "/C", command)
-	} else {
-		cmd = exec.CommandContext(ctx, "/bin/bash", "-lc", command)
-	}
+	cmd := commandShell(ctx, command)
 	cmd.Dir = workDir
 	configureProcess(cmd)
 


### PR DESCRIPTION
# PR：macOS 优先使用现代 Bash

## 描述

### 变更内容

Bash resolution 顺序调整为：

1. `$MCPX_BASH`
2. `/opt/homebrew/bin/bash`
3. `/usr/local/bin/bash`
4. `/bin/bash`

应用到：

- sync shell command
- background Task
- environment inspect

同时：

- `COMMAND_NOT_FOUND` 仅在 exit code `127` 时判定
- Python / Node ephemeral runtime 仍然直接 exec，不经过 Bash

### 背景

macOS 自带 `/bin/bash` 版本较旧，加载现代 shell 环境时可能出现兼容问题，例如 SDKMAN 使用 Bash 4+ 语法。

优先使用 Homebrew 等提供的现代 Bash，可以避免这类环境初始化错误。

另外，command-not-found 也应严格按 exit code `127` 判断，避免把其他执行失败误分类。

### 验证

- `gofmt` ✅
- focused tests ✅
- `go test ./... -count=1` ✅
- `go vet ./...` ✅
- build ✅