### PR TITLE
test(update): 兼容 umask 权限差异

### DIFF
--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -252,6 +252,11 @@ func TestReplaceExecutable(t *testing.T) {
 	if err := os.WriteFile(current, []byte("old"), 0o751); err != nil {
 		t.Fatal(err)
 	}
+	before, err := os.Stat(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedMode := before.Mode().Perm()
 	if err := os.WriteFile(candidate, []byte("new"), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -266,8 +271,8 @@ func TestReplaceExecutable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != "new" || info.Mode().Perm() != 0o751 {
-		t.Fatalf("replacement content=%q mode=%o", content, info.Mode().Perm())
+	if string(content) != "new" || info.Mode().Perm() != expectedMode {
+		t.Fatalf("replacement content=%q mode=%o, want mode=%o", content, info.Mode().Perm(), expectedMode)
 	}
 }
 


### PR DESCRIPTION
# PR：让 update 权限测试兼容当前 umask

## 描述

### 变更内容

调整 `update` 相关测试，使预期文件权限根据当前进程 `umask` 推导，而不是假定固定权限。

只修改测试，不改变 update runtime 行为。

### 背景

不同开发环境和 CI 环境可能使用不同的 `umask`。

原测试直接断言固定权限，在较严格的 `umask`（例如 `077`）下会失败，即使实际行为是正确的。

### 验证

- `gofmt` ✅
- focused tests ✅
- `go test ./... -count=1` ✅
- `go vet ./...` ✅
- build ✅